### PR TITLE
Some elements have setters/getters that might ruin assignment

### DIFF
--- a/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
+++ b/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
@@ -1,18 +1,7 @@
 import puppeteer from 'puppeteer';
 import { getPageAtUrl } from './browser-utils';
 
-const sleep = async (seconds: number) => await new Promise(resolve => setTimeout(resolve, seconds * 1000));
-
-async function clickButtonMultipleTimes(button:  puppeteer.ElementHandle<Element> , times: number) {
-    let clicksTodo = times;
-    do {
-        await button.click();
-        await sleep(1);
-        clicksTodo--;
-    } while(clicksTodo > 0);
-}
-
-describe('widget event handlers sanity', () => {
+describe('getter setter sanity', () => {
     let browser: puppeteer.Browser;
     beforeAll(async () => {
         browser = await puppeteer.launch({
@@ -21,7 +10,7 @@ describe('widget event handlers sanity', () => {
         });
     }, 30000);
 
-    it('should call event handler only once', async () => {
+    it('radioGroup getter shouldnt interfere with setting the property', async () => {
         const waitForTextToBe = (value: string) => {
             const valueOnPage = Array.from(document.querySelectorAll('[data-testid="richTextElement"]'))
             .map(el => (el as HTMLElement).innerText).join('').trim();

--- a/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
+++ b/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
@@ -1,0 +1,47 @@
+import puppeteer from 'puppeteer';
+import { getPageAtUrl } from './browser-utils';
+
+const sleep = async (seconds: number) => await new Promise(resolve => setTimeout(resolve, seconds * 1000));
+
+async function clickButtonMultipleTimes(button:  puppeteer.ElementHandle<Element> , times: number) {
+    let clicksTodo = times;
+    do {
+        await button.click();
+        await sleep(1);
+        clicksTodo--;
+    } while(clicksTodo > 0);
+}
+
+describe('widget event handlers sanity', () => {
+    let browser: puppeteer.Browser;
+    beforeAll(async () => {
+        browser = await puppeteer.launch({
+            // devtools: true,
+            // slowMo: 100,
+        });
+    }, 30000);
+
+    it('should call event handler only once', async () => {
+        const waitForTextToBe = (value: string) => {
+            const valueOnPage = Array.from(document.querySelectorAll('[data-testid="richTextElement"]'))
+            .map(el => (el as HTMLElement).innerText).join('').trim();
+
+            return value === valueOnPage;
+        }
+
+        const getRadioInputValues = () => {
+            return Array.from(document.querySelectorAll('input[type=radio]')).map(el => (el as HTMLInputElement).value);
+        };
+
+        const page = await getPageAtUrl(browser, 'https://yurym4.wixsite.com/react-velo-e2e/velo-element-getter-sanity');
+
+        await page.waitForFunction(waitForTextToBe, {}, "ready");
+
+        const radioValues = await page.evaluate(getRadioInputValues);
+        expect(radioValues).toEqual(["four4","five5", "six6"]);
+    }, 60000);
+
+    afterAll(async () => {
+        await browser.close();
+    });
+});

--- a/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
+++ b/packages/reconciler/__tests__/e2e/element-getter-sanity.spec.ts
@@ -1,6 +1,17 @@
 import puppeteer from 'puppeteer';
 import { getPageAtUrl } from './browser-utils';
 
+const waitForTextToBe = (value: string) => {
+    const valueOnPage = Array.from(document.querySelectorAll('[data-testid="richTextElement"]'))
+    .map(el => (el as HTMLElement).innerText).join('').trim();
+
+    return value === valueOnPage;
+}
+
+const getRadioInputValues = () => {
+    return Array.from(document.querySelectorAll('input[type=radio]')).map(el => (el as HTMLInputElement).value);
+};
+
 describe('getter setter sanity', () => {
     let browser: puppeteer.Browser;
     beforeAll(async () => {
@@ -11,17 +22,6 @@ describe('getter setter sanity', () => {
     }, 30000);
 
     it('radioGroup getter shouldnt interfere with setting the property', async () => {
-        const waitForTextToBe = (value: string) => {
-            const valueOnPage = Array.from(document.querySelectorAll('[data-testid="richTextElement"]'))
-            .map(el => (el as HTMLElement).innerText).join('').trim();
-
-            return value === valueOnPage;
-        }
-
-        const getRadioInputValues = () => {
-            return Array.from(document.querySelectorAll('input[type=radio]')).map(el => (el as HTMLInputElement).value);
-        };
-
         const page = await getPageAtUrl(browser, 'https://yurym4.wixsite.com/react-velo-e2e/velo-element-getter-sanity');
 
         await page.waitForFunction(waitForTextToBe, {}, "ready");

--- a/packages/reconciler/src/utils.ts
+++ b/packages/reconciler/src/utils.ts
@@ -32,7 +32,7 @@ const getCircularReplacer = () => {
           typeof props[key] === 'object'
         ) {
           try {
-            Object.assign(obj[key], props[key]);
+            Object.assign(obj, {[key]: props[key]});
           } catch (ex) {
             console.log(
               `applyPropsOnObjectExcept Object.assign setting ${key} failed: ${(ex as Error).message}`,

--- a/packages/reconciler/src/utils.ts
+++ b/packages/reconciler/src/utils.ts
@@ -29,7 +29,8 @@ const getCircularReplacer = () => {
         if (
           obj[key] &&
           typeof obj[key] === 'object' &&
-          typeof props[key] === 'object'
+          typeof props[key] === 'object' &&
+          !Array.isArray(props[key])
         ) {
           try {
             Object.assign(obj, {

--- a/packages/reconciler/src/utils.ts
+++ b/packages/reconciler/src/utils.ts
@@ -32,7 +32,9 @@ const getCircularReplacer = () => {
           typeof props[key] === 'object'
         ) {
           try {
-            Object.assign(obj, {[key]: props[key]});
+            Object.assign(obj, {
+              [key]: Object.assign(obj[key], props[key])
+            });
           } catch (ex) {
             console.log(
               `applyPropsOnObjectExcept Object.assign setting ${key} failed: ${(ex as Error).message}`,


### PR DESCRIPTION
Some elements have setters/getters that might ruin assignment #7

Specifically there's an issue where a property is an object/array AND the editor element implementation doesn't return a direct reference but a copy of an object, like radio group does here:
[https://github.com/wix-private/editor-elements/blob/ed659298b9f3e41655042a5dd3d745[…]-elements/src/components/RadioGroup/corvid/RadioGroup.corvid.ts](https://github.com/wix-private/editor-elements/blob/ed659298b9f3e41655042a5dd3d7458f42824695/packages/thunderbolt-elements/src/components/RadioGroup/corvid/RadioGroup.corvid.ts#L50)

